### PR TITLE
Pass correct cmake arguments for swift-5.0.

### DIFF
--- a/com.ibm.wala.cast.swift/swift-wala-translator/build.gradle
+++ b/com.ibm.wala.cast.swift/swift-wala-translator/build.gradle
@@ -27,9 +27,8 @@ project(":swift-wala-translator") {
                     cmakeArgs "-DCMAKE_INSTALL_PREFIX=${outputDir}",
                             "-DCMAKE_C_COMPILER=clang",
                             "-DCMAKE_CXX_COMPILER=clang++",
-                            "-DWALA_PATH_TO_SWIFT_BUILD=${WALA_PATH_TO_SWIFT_BUILD}",
-                            "-DSWIFT_PATH_TO_LLVM_SOURCE=${SWIFT_PATH_TO_LLVM_SOURCE}",
-                            "-DSWIFT_PATH_TO_LLVM_BUILD=${SWIFT_PATH_TO_LLVM_BUILD}",
+                            "-DClang_DIR=${SWIFT_PATH_TO_LLVM_BUILD}/lib/cmake/clang",
+                            "-DLLVM_DIR=${SWIFT_PATH_TO_LLVM_BUILD}/lib/cmake/llvm",
                             "-DSWIFT_PATH_TO_CMARK_BUILD=${SWIFT_PATH_TO_CMARK_BUILD}",
                             "-DWALA_DIR=${WALA_DIR}"
                     targets 'swiftWala', 'install'


### PR DESCRIPTION
Fixed the issue #31 
The upstream swift made some breaking changes and this pr doesn't fix all of them. This patch only helps swan to find correct cmake args. You may still need to modify the source code to fix the build. 