### PR TITLE
chore: add SwiftDemangleLocator

### DIFF
--- a/jvm/ca.ualberta.maple.swan.drivers/src/ca/ualberta/maple/swan/drivers/Driver.scala
+++ b/jvm/ca.ualberta.maple.swan.drivers/src/ca/ualberta/maple/swan/drivers/Driver.scala
@@ -31,7 +31,7 @@ import ca.ualberta.maple.swan.spds.analysis.taint._
 import ca.ualberta.maple.swan.spds.analysis.typestate.{TypeStateAnalysis, TypeStateResults}
 import ca.ualberta.maple.swan.spds.cg.CallGraphBuilder.CallGraphStyle.Style
 import ca.ualberta.maple.swan.spds.cg.{CallGraphBuilder, CallGraphConstructor, CallGraphUtils}
-import ca.ualberta.maple.swan.utils.Logging
+import ca.ualberta.maple.swan.utils.{Logging, SwiftDemangleLocator}
 import org.apache.commons.io.{FileExistsException, FileUtils, IOUtils}
 import picocli.CommandLine
 import picocli.CommandLine.{ArgGroup, Command, Option, Parameters}
@@ -329,8 +329,13 @@ class Driver extends Runnable {
       throw new FileExistsException("swan-dir does not exist")
     }
 
+    var swiftDemangleLocation: String = SwiftDemangleLocator.swiftDemangleLocation()
+    if swiftDemangleLocation == null then {
+      throw new FileExistsException("Cannot find swift-demangle. Create a symbolic link for swift-demangle in /usr/local/bin/ or add it to $PATH.")
+    }
+
     try
-      ("swift-demangle --version").!!
+      (s"$swiftDemangleLocation --version").!!
     catch
       case e: Exception => throw new FileExistsException("Cannot find swift-demangle. Create a symbolic link for swift-demangle in /usr/local/bin/ or add it to $PATH.")
 

--- a/jvm/ca.ualberta.maple.swan.parser/src/scala/ca/ualberta/maple/swan/parser/SILParser.scala
+++ b/jvm/ca.ualberta.maple.swan.parser/src/scala/ca/ualberta/maple/swan/parser/SILParser.scala
@@ -24,7 +24,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 import java.util
 
-import ca.ualberta.maple.swan.utils.Logging
+import ca.ualberta.maple.swan.utils.{Logging, SwiftDemangleLocator}
 
 import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
@@ -44,7 +44,7 @@ class SILParser extends SILPrinter {
   private var cursor: Int = 0
   def position(): Int = { cursor }
 
-  var swiftDemangleCommand = "swift-demangle -compact "
+  var swiftDemangleCommand = s"${SwiftDemangleLocator.swiftDemangleLocation()} -compact "
 
   private val toDemangle: ArrayBuffer[SILMangledName] = new ArrayBuffer[SILMangledName]
 

--- a/jvm/ca.ualberta.maple.swan.utils/src/ca/ualberta/maple/swan/utils/SwiftDemangleLocator.scala
+++ b/jvm/ca.ualberta.maple.swan.utils/src/ca/ualberta/maple/swan/utils/SwiftDemangleLocator.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021 the SWAN project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This software has dependencies with other licenses.
+ * See https://github.com/themaplelab/swan/doc/LICENSE.md.
+ */
+
+package ca.ualberta.maple.swan.utils
+import sys.process.*
+
+object SwiftDemangleLocator {
+
+  def swiftDemangleLocation(): String = {
+    var swiftDemangleBinName = "swift-demangle"
+    val result = s"which $swiftDemangleBinName".!
+
+    if (result == 0) { return s"which $swiftDemangleBinName".!!.trim }
+
+    val osName: String = System.getProperty("os.name").toLowerCase
+    val isMacOs: Boolean = osName.startsWith("mac os x")
+    // Can't resolve on Linux. Checker will throw expection.
+    if (!isMacOs) { return null }
+
+    // Get path to the active developer directory.
+    var selectedXcode = "xcode-select -p".!!.trim
+    var swiftDemanglePath: String = null
+    // If it's command line tools
+    if (selectedXcode.startsWith("/Library/Developer/CommandLineTools")) {
+      swiftDemanglePath = selectedXcode + s"/usr/bin/$swiftDemangleBinName"
+    // If it's Xcode.app
+    } else if (selectedXcode.endsWith(".app/Contents/Developer")) {
+      swiftDemanglePath = selectedXcode + s"/Toolchains/XcodeDefault.xctoolchain/usr/bin/$swiftDemangleBinName"
+    }
+
+    return swiftDemanglePath
+  }
+}


### PR DESCRIPTION
There is no need in symlinks for `swift-demangle` on macOS. In most cases it can be found by using `xcode-select -p` and appending a correct folder, depending on what developer dir is selected.

I deliberately didn't add `/Application/Xcode` to the search prefix because I have several Xcodes on my mac and path can vary.