### PR TITLE
Add 'type' advance-debug-var-attr to parser

### DIFF
--- a/jvm/ca.ualberta.maple.swan.parser/src/scala/ca/ualberta/maple/swan/parser/SIL.scala
+++ b/jvm/ca.ualberta.maple.swan.parser/src/scala/ca/ualberta/maple/swan/parser/SIL.scala
@@ -451,6 +451,7 @@ object SILDebugAttribute {
   case object let extends SILDebugAttribute
   case object variable extends SILDebugAttribute
   case object _implicit extends SILDebugAttribute
+  case class tpe(tpe: SILType) extends SILDebugAttribute
 }
 
 class SILDebugInfoExpr(val operand: SILDiExprOperand, val otherOperands: Option[ArrayBuffer[SILDiExprOperand]])

--- a/jvm/ca.ualberta.maple.swan.parser/src/scala/ca/ualberta/maple/swan/parser/SILParser.scala
+++ b/jvm/ca.ualberta.maple.swan.parser/src/scala/ca/ualberta/maple/swan/parser/SILParser.scala
@@ -2040,6 +2040,7 @@ class SILParser extends SILPrinter {
     if(skip("let")) return Some(SILDebugAttribute.let)
     if(skip("var")) return Some(SILDebugAttribute.variable)
     if(skip("implicit")) return Some(SILDebugAttribute.variable)
+    if(skip("type")) return Some(SILDebugAttribute.tpe(parseType()))
     this.cursor = c
     None
   }


### PR DESCRIPTION
This change adds support for the 'type' advanced debug var attribute: https://github.com/swiftlang/swift/blob/main/docs/SIL/Instructions.md#debug-information